### PR TITLE
暫停後再啟動，接續之前的結果繼續計時

### DIFF
--- a/basic_stop_watch/src/StopWatch.js
+++ b/basic_stop_watch/src/StopWatch.js
@@ -28,10 +28,9 @@ class StopWatch extends React.Component {
   }
 
   onStart = () => {
-    let diff = this.state.currentTime - this.state.startTime;
     this.setState({
       isStarted: true,
-      startTime: new Date() - diff,
+      startTime: new Date() - this.state.currentTime - this.state.startTime,
       currentTime: new Date(),
     });
 

--- a/basic_stop_watch/src/StopWatch.js
+++ b/basic_stop_watch/src/StopWatch.js
@@ -28,9 +28,10 @@ class StopWatch extends React.Component {
   }
 
   onStart = () => {
+    let diff = this.state.currentTime - this.state.startTime;
     this.setState({
       isStarted: true,
-      startTime: new Date(),
+      startTime: new Date() - diff,
       currentTime: new Date(),
     });
 


### PR DESCRIPTION
reproduce step:
start->pause->start
StopWatch會從0開始計時，預期結果是click start時，StartWatch接續pause的時間繼續計時

solution:
增加一個變數計算startTime-currentTime，讓onStart擁有繼續計時的功能